### PR TITLE
Replace flake8 and isort with Ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,9 +1,0 @@
-[flake8]
-max-line-length = 88
-extend-ignore = E203
-exclude = .venv
-required-plugins =
-	flake8-docstring,
-docstring-convention = google
-per-file-ignores =
-    tests/*:D100,D104

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
     rev: 'v0.0.257'
     hooks:
       - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.2.0"
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,20 +4,14 @@ repos:
     hooks:
       - id: check-merge-conflict
       - id: debug-statements
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        additional_dependencies: [toml]
   - repo: https://github.com/psf/black
     rev: "23.3.0"
     hooks:
       - id: black
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: 'v0.0.257'
     hooks:
-      - id: flake8
-        additional_dependencies: [flake8-docstrings]
+      - id: ruff
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.2.0"
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,7 @@ dependencies = []
 [project.optional-dependencies]
 dev = [
     "black",
-    "flake8",
-    "flake8-docstrings",
-    "isort",
+    "ruff",
     "mypy",
     "pip-tools",
     "pre-commit",
@@ -40,8 +38,14 @@ exclude = [".venv/"]
 module = "tests.*"
 disallow_untyped_defs = false
 
-[tool.isort]
-profile = "black"
-
 [tool.pytest.ini_options]
 addopts = "-v --mypy -p no:warnings --cov=datahub --cov-report=html --doctest-modules --ignore=datahub/__main__.py"
+
+[tool.ruff]
+select = ["D", "E", "F", "I"] # pydocstyle, pycodestyle, Pyflakes, isort
+
+[tool.ruff.per-file-ignores]
+"tests/*" = ["D100", "D104"]
+
+[tool.ruff.pydocstyle]
+convention = "google"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,20 +28,10 @@ filelock==3.11.0
     # via
     #   pytest-mypy
     #   virtualenv
-flake8==6.0.0
-    # via
-    #   datahub (pyproject.toml)
-    #   flake8-docstrings
-flake8-docstrings==1.7.0
-    # via datahub (pyproject.toml)
-identify==2.5.22
+identify==2.5.18
     # via pre-commit
 iniconfig==2.0.0
     # via pytest
-isort==5.12.0
-    # via datahub (pyproject.toml)
-mccabe==0.7.0
-    # via flake8
 mypy==1.2.0
     # via
     #   datahub (pyproject.toml)
@@ -69,12 +59,6 @@ pluggy==1.0.0
     # via pytest
 pre-commit==3.2.2
     # via datahub (pyproject.toml)
-pycodestyle==2.10.0
-    # via flake8
-pydocstyle==6.3.0
-    # via flake8-docstrings
-pyflakes==3.0.1
-    # via flake8
 pyproject-hooks==1.0.0
     # via build
 pytest==7.3.0
@@ -91,8 +75,8 @@ pytest-mypy==0.10.3
     # via datahub (pyproject.toml)
 pyyaml==6.0
     # via pre-commit
-snowballstemmer==2.2.0
-    # via pydocstyle
+ruff==0.0.257
+    # via datahub (pyproject.toml)
 tomli==2.0.1
     # via
     #   black

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,9 +5,7 @@
 #    pip-compile --extra=dev --output-file=requirements-dev.txt
 #
 attrs==22.2.0
-    # via
-    #   pytest
-    #   pytest-mypy
+    # via pytest-mypy
 black==23.3.0
     # via datahub (pyproject.toml)
 build==0.10.0
@@ -28,7 +26,7 @@ filelock==3.11.0
     # via
     #   pytest-mypy
     #   virtualenv
-identify==2.5.18
+identify==2.5.22
     # via pre-commit
 iniconfig==2.0.0
     # via pytest
@@ -42,7 +40,7 @@ mypy-extensions==1.0.0
     #   mypy
 nodeenv==1.7.0
     # via pre-commit
-packaging==23.0
+packaging==23.1
     # via
     #   black
     #   build
@@ -75,7 +73,7 @@ pytest-mypy==0.10.3
     # via datahub (pyproject.toml)
 pyyaml==6.0
     # via pre-commit
-ruff==0.0.257
+ruff==0.0.261
     # via datahub (pyproject.toml)
 tomli==2.0.1
     # via


### PR DESCRIPTION
This PR replaces flake8 and isort with [Ruff](https://github.com/charliermarsh/ruff)

Advantages:
- Faster
- Supports pyproject.toml (unlike flake8)

It remains to be seen if this configuration is exactly the same as the pre-existing one.

Install by either running `pip install -r requirements-dev.txt` or update existing installation with `pip-sync requirements-dev.txt requirements.txt`