### PR TITLE
Opal API - Array Format Input

### DIFF
--- a/datahub/main.py
+++ b/datahub/main.py
@@ -62,8 +62,8 @@ class OpalArrayData(BaseModel):
 
 
 @app.post("/opal")
-def create_data(data: OpalDictData | OpalArrayData) -> dict[str, float]:
-    """Post method function for appending data to Opal dataframe.
+def create_opal_data(data: OpalDictData | OpalArrayData) -> dict[str, float]:
+    """POST method function for appending data to Opal Dataframe.
 
     Args:
         data: The raw opal data in either Dict or List format
@@ -94,3 +94,15 @@ def create_data(data: OpalDictData | OpalArrayData) -> dict[str, float]:
     print(dt.opal_df)
 
     return raw_data
+
+
+@app.get("/opal")
+def get_opal_data() -> dict[str, float]:
+    """GET method function for getting Opal Dataframe as JSON.
+
+    Returns:
+        A Dict of the Opal Dataframe in JSON format
+    """
+    # Requires opal-test branch to be merged
+    # return dt.opal_df.to_json()
+    return {"test": 0}


### PR DESCRIPTION
Updated POST method for Opal data to accept data input as array format as well as key value dictionary.

Also added a placeholder GET method for Opal data, however this will only be functional once https://github.com/ImperialCollegeLondon/gridlington-datahub/pull/61 has been merged since `.to_json()` isn't compatible with the multiple 'N/A' columns.

Closes https://github.com/ImperialCollegeLondon/gridlington-datahub/issues/50

You can test this new functionality by running the server with `uvicorn datahub.main:app --reload`

And using this dummy data:
```
{
    "array": [
        1,
        8.58,
        34.9085,
        34.9055,
        16.177,
        7.8868,
        15.1744,
        3.3549,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        16192.8871,
        16194.8348,
        -0.5713,
        -0.8467,
        16.2002,
        9.0618,
        0.2806,
        -2.1328,
        0,
        0.7931,
        0.0522,
        0.0522,
        34.8373,
        34.8343,
        0,
        0,
        30.801,
        30.801,
        28,
        5,
        63,
        72,
        0,
        303,
        7230,
        3.774,
        3.774,
        510,
        2,
        34
    ]
}
```
