### PR TITLE
Opal Pydantic Model

### DIFF
--- a/datahub/main.py
+++ b/datahub/main.py
@@ -6,55 +6,9 @@ from pydantic import BaseModel
 
 from . import data as dt
 from .dsr import DSRModel, validate_dsr_sizes
+from .opal import OpalModel
 
 app = FastAPI()
-
-
-class OpalDictData(BaseModel):
-    """Class for defining required key values for Opal data as a dict."""
-
-    frame: int
-    time: float
-    total_gen: float
-    total_dem: float
-    total_offwind: float
-    intra_trade: float
-    intra_gen: float
-    intra_dem: float
-    intra_sto: float
-    bm_gen: float
-    bm_sto: float
-    bm_dem: float
-    offwind_exp: float
-    offwind_real: float
-    bat_gen: float
-    inter_gen: float
-    offwind_gen: float
-    onwind_gen: float
-    other_gen: float
-    pump_gen: float
-    pv_gen: float
-    nc_gen: float
-    hyd_gen: float
-    gas_gen: float
-    total_exp: float
-    total_real: float
-    bm_cost: float
-    bm_accept: float
-    exp_dem: float
-    real_dem: float
-    act_work: int
-    act_study: int
-    act_home: int
-    act_pers: int
-    act_shop: int
-    act_leis: int
-    act_sleep: int
-    exp_ev: float
-    real_ev: float
-    ev_charge: int
-    ev_travel: int
-    ev_idle: int
 
 
 class OpalArrayData(BaseModel):
@@ -64,7 +18,7 @@ class OpalArrayData(BaseModel):
 
 
 @app.post("/opal")
-def create_opal_data(data: OpalDictData | OpalArrayData) -> dict[str, str]:
+def create_opal_data(data: OpalModel | OpalArrayData) -> dict[str, str]:
     """POST method function for appending data to Opal Dataframe.
 
     Args:

--- a/datahub/opal.py
+++ b/datahub/opal.py
@@ -1,52 +1,64 @@
 """This module defines the data structures for the Opal model."""
-
 import pandas as pd
+from pydantic import BaseModel, Field
 
 OPAL_START_DATE = "2035-01-22 00:00"
 
-opal_headers = {
-    "Time": "time",
-    "Total Generation": "total_gen",
-    "Total Demand": "total_dem",
-    "Total Offshore Generation": "total_offwind",
-    "Intra-day Market Value": "intra_trade",
-    "Intra-day Market Generation": "intra_gen",
-    "Intra-day Market Demand": "intra_dem",
-    "Intra-day Market Storage": "intra_sto",
-    "Balancing Mechanism Generation": "bm_gen",
-    "Balancing Mechanism Storage": "bm_sto",
-    "Balancing Mechanism Demand": "bm_dem",
-    "Exp. Offshore Wind Generation": "offwind_exp",
-    "Real Offshore Wind Generation": "offwind_real",
-    "Battery Generation": "bat_gen",
-    "Interconnector Power": "inter_gen",
-    "Offshore Wind Generation": "offwind_gen",
-    "Onshore Wind Generation": "onwind_gen",
-    "Other Generation": "other_gen",
-    "Pump Generation": "pump_gen",
-    "PV Generation": "pv_gen",
-    "Nuclear Generation": "nc_gen",
-    "Hydro Generation": "hyd_gen",
-    "Gas Generation": "gas_gen",
-    "Expected Demand": "total_exp",
-    "Real Demand": "total_real",
-    "Balancing Mechanism Value": "bm_cost",
-    "Balancing Mechanism Accepted Power": "bm_accept",
-    "Expected Gridlington Demand": "exp_dem",
-    "Real Gridlington Demand": "real_dem",
-    "Household Activity (Work)": "act_work",
-    "Household Activity (Study)": "act_study",
-    "Household Activity (Home Care)": "act_home",
-    "Household Activity (Personal Care)": "act_pers",
-    "Household Activity (Shopping)": "act_shop",
-    "Household Activity (Leisure)": "act_leis",
-    "Household Activity (Sleep)": "act_sleep",
-    "Expected EV Charging Power": "exp_ev",
-    "Real EV Charging Power": "real_ev",
-    "EV Status (Charging)": "ev_charge",
-    "EV Status (Travelling)": "ev_travel",
-    "EV Status (Idle)": "ev_idle",
-}
+
+class Opal(BaseModel):
+    """Define required key values for Demand Side Response data."""
+
+    frame: int
+    time: float = Field(alias="Time")
+    total_gen: float = Field(alias="Total Generation")
+    total_dem: float = Field(alias="Total Demand")
+    total_offwind: float = Field(alias="Total Offshore Generation")
+    intra_trade: float = Field(alias="Intra-day Market Value")
+    intra_gen: float = Field(alias="Intra-day Market Generation")
+    intra_dem: float = Field(alias="Intra-day Market Demand")
+    intra_sto: float = Field(alias="Intra-day Market Storage")
+    bm_gen: float = Field(alias="Balancing Mechanism Generation")
+    bm_sto: float = Field(alias="Balancing Mechanism Storage")
+    bm_dem: float = Field(alias="Balancing Mechanism Demand")
+    offwind_exp: float = Field(alias="Exp. Offshore Wind Generation")
+    offwind_real: float = Field(alias="Real Offshore Wind Generation")
+    bat_gen: float = Field(alias="Battery Generation")
+    inter_gen: float = Field(alias="Interconnector Power")
+    offwind_gen: float = Field(alias="Offshore Wind Generation")
+    onwind_gen: float = Field(alias="Onshore Wind Generation")
+    other_gen: float = Field(alias="Other Generation")
+    pump_gen: float = Field(alias="Pump Generation")
+    pv_gen: float = Field(alias="PV Generation")
+    nc_gen: float = Field(alias="Nuclear Generation")
+    hyd_gen: float = Field(alias="Hydro Generation")
+    gas_gen: float = Field(alias="Gas Generation")
+    total_exp: float = Field(alias="Expected Demand")
+    total_real: float = Field(alias="Real Demand")
+    bm_cost: float = Field(alias="Balancing Mechanism Value")
+    bm_accept: float = Field(alias="Balancing Mechanism Accepted Power")
+    exp_dem: float = Field(alias="Expected Gridlington Demand")
+    real_dem: float = Field(alias="Real Gridlington Demand")
+    act_work: int = Field(alias="Household Activity (Work)")
+    act_study: int = Field(alias="Household Activity (Study)")
+    act_home: int = Field(alias="Household Activity (Home Care)")
+    act_pers: int = Field(alias="Household Activity (Personal Care)")
+    act_shop: int = Field(alias="Household Activity (Shopping)")
+    act_leis: int = Field(alias="Household Activity (Leisure)")
+    act_sleep: int = Field(alias="Household Activity (Sleep)")
+    exp_ev: float = Field(alias="Expected EV Charging Power")
+    real_ev: float = Field(alias="Real EV Charging Power")
+    ev_charge: int = Field(alias="EV Status (Charging)")
+    ev_travel: int = Field(alias="EV Status (Travelling)")
+    ev_idle: int = Field(alias="EV Status (Idle)")
+
+    class Config:
+        """Allow the field variable names to be used in the API call."""
+
+        allow_population_by_field_name = True
+
+
+opal_headers = {field.alias: field.name for field in Opal.__fields__.values()}
+del opal_headers["frame"]
 
 
 @pd.api.extensions.register_dataframe_accessor("opal")

--- a/datahub/opal.py
+++ b/datahub/opal.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, Field
 OPAL_START_DATE = "2035-01-22 00:00"
 
 
-class Opal(BaseModel):
+class OpalModel(BaseModel):
     """Define required key values for Demand Side Response data."""
 
     frame: int
@@ -57,7 +57,7 @@ class Opal(BaseModel):
         allow_population_by_field_name = True
 
 
-opal_headers = {field.alias: field.name for field in Opal.__fields__.values()}
+opal_headers = {field.alias: field.name for field in OpalModel.__fields__.values()}
 del opal_headers["frame"]
 
 

--- a/datahub/opal.py
+++ b/datahub/opal.py
@@ -57,7 +57,11 @@ class OpalModel(BaseModel):
         allow_population_by_field_name = True
 
 
-opal_headers = {field.alias: field.name for field in OpalModel.__fields__.values() if field.name != "frame"}
+opal_headers = {
+    field.alias: field.name
+    for field in OpalModel.__fields__.values()
+    if field.name != "frame"
+}
 
 
 @pd.api.extensions.register_dataframe_accessor("opal")

--- a/datahub/opal.py
+++ b/datahub/opal.py
@@ -57,8 +57,7 @@ class OpalModel(BaseModel):
         allow_population_by_field_name = True
 
 
-opal_headers = {field.alias: field.name for field in OpalModel.__fields__.values()}
-del opal_headers["frame"]
+opal_headers = {field.alias: field.name for field in OpalModel.__fields__.values() if field.name != "frame"}
 
 
 @pd.api.extensions.register_dataframe_accessor("opal")

--- a/datahub/opal.py
+++ b/datahub/opal.py
@@ -6,7 +6,7 @@ OPAL_START_DATE = "2035-01-22 00:00"
 
 
 class OpalModel(BaseModel):
-    """Define required key values for Demand Side Response data."""
+    """Define required key values for Opal data."""
 
     frame: int
     time: float = Field(alias="Time")


### PR DESCRIPTION
`OpalDictData` model replaced with new Pydantic model that includes the `opal_headers` column header strings as field aliases. The model has been relocated from `main.py` to `opal.py`.

Closes https://github.com/ImperialCollegeLondon/gridlington-datahub/issues/63