### PR TITLE
Reduce type checking to improve DSRModel performance

### DIFF
--- a/datahub/data.py
+++ b/datahub/data.py
@@ -1,6 +1,4 @@
 """This module defines the data structures for each of the models."""
-from typing import Any
-
 from .opal import create_opal_frame
 
 opal_data = [
@@ -51,9 +49,8 @@ opal_data = [
     34,
 ]
 
-
 opal_df = create_opal_frame()
-dsr_data: list[dict[str, Any]] = []  # type: ignore[misc]
+dsr_data: list[dict[str, str | list]] = []  # type: ignore[type-arg]
 
 
 if __name__ == "__main__":

--- a/datahub/dsr.py
+++ b/datahub/dsr.py
@@ -1,6 +1,4 @@
 """This module defines the data structures for the MEDUSA Demand Simulator model."""
-from typing import Any
-
 import numpy as np
 from pydantic import BaseModel, Field
 
@@ -35,7 +33,7 @@ class DSRModel(BaseModel):
         allow_population_by_field_name = True
 
 
-def validate_dsr_arrays(data: dict[str, Any]) -> list[str]:  # type: ignore[misc]
+def validate_dsr_arrays(data: dict[str, str | list]) -> list[str]:
     """Validate the sizes of the arrays in the DSR data.
 
     Args:

--- a/datahub/dsr.py
+++ b/datahub/dsr.py
@@ -1,36 +1,31 @@
 """This module defines the data structures for the MEDUSA Demand Simulator model."""
 from typing import Any
 
+import numpy as np
 from pydantic import BaseModel, Field
 
 
 class DSRModel(BaseModel):
     """Define required key values for Demand Side Response data."""
 
-    amount: list[float] = Field(alias="Amount", size=(13,))
-    cost: list[list[float]] = Field(alias="Cost", size=(1440, 13))
-    kwh_cost: list[float] = Field(alias="kWh Cost", size=(2,))
-    activities: list[list[float]] = Field(alias="Activities", size=(1440, 7))
-    activities_outside_home: list[list[float]] = Field(
+    amount: list = Field(alias="Amount", size=(13,))
+    cost: list = Field(alias="Cost", size=(1440, 13))
+    kwh_cost: list = Field(alias="kWh Cost", size=(2,))
+    activities: list = Field(alias="Activities", size=(1440, 7))
+    activities_outside_home: list = Field(
         alias="Activities Outside Home", size=(1440, 7)
     )
-    activity_types: list[float] = Field(alias="Activity Types", size=(7,))
-    ev_id_matrix: list[list[float]] = Field(
-        alias="EV ID Matrix", default=None, size=(1440, 4329)
-    )
-    ev_dt: list[list[float]] = Field(alias="EV DT", size=(1440, 2))
-    ev_locations: list[list[float]] = Field(
-        alias="EV Locations", default=None, size=(1440, 4329)
-    )
-    ev_battery: list[list[float]] = Field(
-        alias="EV Battery", default=None, size=(1440, 4329)
-    )
-    ev_state: list[list[float]] = Field(alias="EV State", size=(1440, 4329))
-    ev_mask: list[list[float]] = Field(alias="EV Mask", default=None, size=(1440, 4329))
-    baseline_ev: list[float] = Field(alias="Baseline EV", size=(1440,))
-    baseline_non_ev: list[float] = Field(alias="Baseline Non-EV", size=(1440,))
-    actual_ev: list[float] = Field(alias="Actual EV", size=(1440,))
-    actual_non_ev: list[float] = Field(alias="Actual Non-EV", size=(1440,))
+    activity_types: list = Field(alias="Activity Types", size=(7,))
+    ev_id_matrix: list = Field(alias="EV ID Matrix", default=None, size=(1440, 4329))
+    ev_dt: list = Field(alias="EV DT", size=(1440, 2))
+    ev_locations: list = Field(alias="EV Locations", default=None, size=(1440, 4329))
+    ev_battery: list = Field(alias="EV Battery", default=None, size=(1440, 4329))
+    ev_state: list = Field(alias="EV State", size=(1440, 4329))
+    ev_mask: list = Field(alias="EV Mask", default=None, size=(1440, 4329))
+    baseline_ev: list = Field(alias="Baseline EV", size=(1440,))
+    baseline_non_ev: list = Field(alias="Baseline Non-EV", size=(1440,))
+    actual_ev: list = Field(alias="Actual EV", size=(1440,))
+    actual_non_ev: list = Field(alias="Actual Non-EV", size=(1440,))
     name: str = Field(alias="Name", default="")
     warn: str = Field(alias="Warn", default="")
 
@@ -40,24 +35,23 @@ class DSRModel(BaseModel):
         allow_population_by_field_name = True
 
 
-def validate_dsr_sizes(data: dict[str, Any]) -> list[str]:  # type: ignore[misc]
+def validate_dsr_arrays(data: dict[str, Any]) -> list[str]:  # type: ignore[misc]
     """Validate the sizes of the arrays in the DSR data.
 
     Args:
         data: The dictionary representation of the DSR Data. The keys are field aliases.
+            It is generated with the data.dict(by_alias=True) where data is a DSRModel.
 
     Returns:
         An empty list if there are no issues. A list of the failing fields if there are.
     """
     aliases = []
     for field in list(DSRModel.__fields__.values()):
-        if field.annotation == list[list[float]]:
-            rows = len(data[field.alias])
-            cols = len(data[field.alias][0])
-            if (rows, cols) != field.field_info.extra["size"]:
-                aliases.append(field.alias)
-        elif field.annotation == list[float]:
-            rows = len(data[field.alias])
-            if (rows,) != field.field_info.extra["size"]:
+        if field.annotation == list:
+            array = np.array(data[field.alias])
+            if (
+                array.shape != field.field_info.extra["size"]
+                or array.dtype != np.float64
+            ):
                 aliases.append(field.alias)
     return aliases

--- a/datahub/dsr.py
+++ b/datahub/dsr.py
@@ -44,12 +44,13 @@ def validate_dsr_arrays(data: dict[str, str | list]) -> list[str]:
         An empty list if there are no issues. A list of the failing fields if there are.
     """
     aliases = []
-    for field in list(DSRModel.__fields__.values()):
-        if field.annotation == list:
-            array = np.array(data[field.alias])
-            if (
-                array.shape != field.field_info.extra["size"]
-                or array.dtype != np.float64
-            ):
-                aliases.append(field.alias)
+    for alias, field in DSRModel.schema()["properties"].items():
+        if field["type"] == "array":
+            try:
+                array = np.array(data[alias])
+            except ValueError:
+                aliases.append(alias)
+                continue
+            if array.shape != field["size"] or array.dtype != np.float64:
+                aliases.append(alias)
     return aliases

--- a/datahub/main.py
+++ b/datahub/main.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
 from . import data as dt
-from .dsr import DSRModel, validate_dsr_sizes
+from .dsr import DSRModel, validate_dsr_arrays
 from .opal import OpalModel
 
 app = FastAPI()
@@ -78,7 +78,7 @@ def update_dsr_data(data: DSRModel) -> dict[str, str]:
         A HTTPException if the data is invalid
     """
     data_dict = data.dict(by_alias=True)
-    if alias := validate_dsr_sizes(data_dict):
+    if alias := validate_dsr_arrays(data_dict):
         raise HTTPException(
             status_code=400, detail=f"Invalid size for: {', '.join(alias)}."
         )

--- a/datahub/opal.py
+++ b/datahub/opal.py
@@ -58,9 +58,9 @@ class OpalModel(BaseModel):
 
 
 opal_headers = {
-    field.alias: field.name
-    for field in OpalModel.__fields__.values()
-    if field.name != "frame"
+    field["title"]: name
+    for name, field in OpalModel.schema(by_alias=False)["properties"].items()
+    if name != "frame"
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,14 @@ exclude = ["htmlcov"]
 
 [tool.mypy]
 disallow_any_explicit = true
+disallow_any_generics = true
 warn_unreachable = true
 disallow_untyped_defs = true
 exclude = [".venv/"]
+
+[[tool.mypy.overrides]]
+module = "datahub.dsr"
+disallow_any_generics = false
 
 [[tool.mypy.overrides]]
 module = "tests.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ exclude = ["htmlcov"]
 
 [tool.mypy]
 disallow_any_explicit = true
-disallow_any_generics = true
 warn_unreachable = true
 disallow_untyped_defs = true
 exclude = [".venv/"]

--- a/tests/test_dsr.py
+++ b/tests/test_dsr.py
@@ -45,7 +45,7 @@ def test_post_dsr_api_invalid(dsr_data):
     """Tests POSTing DSR data to API."""
     # Checks invalid array lengths raises an error
     dsr_data["Amount"].append(1.0)
-    dsr_data["Cost"].pop()
+    dsr_data["Cost"][0].pop()
 
     response = client.post("/dsr", data=json.dumps(dsr_data))
     assert response.status_code == 400


### PR DESCRIPTION
The `DSRModel` was taking a very long time to process the full set of data that would come in 1 request (about 18 seconds in the tests), see #71. It appears like this is due to Pydantic checking the type of every element of the array data.

This PR removes the nested type definitions in the DSRModel and just annotates each array (whether 2D or not) as a `list`. The size and type of the data are checked more efficiently later by converting them into numpy arrays. This reduces the time taken to instantiate the `DSRModel` to the order of 10s of microseconds.

One consequence on this was reducing the mypy restrictions to allow generic typedefs - I think this is a good thing because the more specific internal types of the return values for many pandas functions appear to be incomplete in the pandas-stubs.

This PR is opened as a draft to solicit opinions on this approach.