### PR TITLE
Vis API Endpoints

### DIFF
--- a/datahub/main.py
+++ b/datahub/main.py
@@ -56,7 +56,7 @@ def get_opal_data() -> dict[Hashable, Any]:  # type: ignore[misc]
     """GET method function for getting Opal Dataframe as JSON.
 
     Returns:
-        A Dict of the Opal Dataframe in JSON format.
+        A Dict containing the Opal Dataframe in JSON format.
 
         This can be converted back to a Dataframe using the following:
         pd.DataFrame(**data)
@@ -104,7 +104,7 @@ def get_wesim_data() -> dict[Hashable, Any]:  # type: ignore[misc]
     """GET method function for getting WESIM data as JSON.
 
     Returns:
-        A Dict containing the DSR list.
+        A Dict containing the WESIM data in JSON format.
     """
     data = get_wesim()
     return {"data": data}

--- a/datahub/main.py
+++ b/datahub/main.py
@@ -62,7 +62,7 @@ def get_opal_data() -> dict[Hashable, Any]:  # type: ignore[misc]
         pd.DataFrame(**data)
     """
     data = dt.opal_df.to_dict(orient="split")
-    return data
+    return {"data": data}
 
 
 @app.post("/dsr")

--- a/datahub/main.py
+++ b/datahub/main.py
@@ -52,7 +52,9 @@ def create_opal_data(data: OpalModel | OpalArrayData) -> dict[str, str]:
 
 # TODO: Fix return typing annotation
 @app.get("/opal")
-def get_opal_data() -> dict[Hashable, Any]:  # type: ignore[misc]
+def get_opal_data(  # type: ignore[misc]
+    start: int = 0, end: int | None = None
+) -> dict[Hashable, Any]:
     """GET method function for getting Opal Dataframe as JSON.
 
     Returns:
@@ -61,7 +63,15 @@ def get_opal_data() -> dict[Hashable, Any]:  # type: ignore[misc]
         This can be converted back to a Dataframe using the following:
         pd.DataFrame(**data)
     """
-    data = dt.opal_df.to_dict(orient="split")
+    filtered_df = dt.opal_df.loc[dt.opal_df.index >= start]
+
+    if end:
+        filtered_df = filtered_df.loc[filtered_df.index <= end]
+
+    if filtered_df.empty:
+        raise HTTPException(status_code=404, detail="No data found matching criteria.")
+
+    data = filtered_df.to_dict(orient="split")
     return {"data": data}
 
 

--- a/datahub/main.py
+++ b/datahub/main.py
@@ -99,14 +99,20 @@ def update_dsr_data(data: DSRModel) -> dict[str, str]:
 
 
 @app.get("/dsr")
-def get_dsr_data() -> dict[Hashable, Any]:  # type: ignore[misc]
+def get_dsr_data(  # type: ignore[misc]
+    start: int = 0, end: int | None = None
+) -> dict[Hashable, Any]:
     """GET method function for getting DSR data as JSON.
 
     Returns:
         A Dict containing the DSR list.
     """
-    data = dt.dsr_data
-    return {"data": data}
+    filtered_data = dt.dsr_data[start:]
+
+    if end:
+        filtered_data = filtered_data[: end - start + 1]
+
+    return {"data": filtered_data}
 
 
 @app.get("/wesim")

--- a/datahub/main.py
+++ b/datahub/main.py
@@ -107,4 +107,7 @@ def get_wesim_data() -> dict[Hashable, Any]:  # type: ignore[misc]
         A Dict containing the WESIM data in JSON format.
     """
     data = get_wesim()
+    for value in data.values():
+        value = value.to_dict(orient="split")
+
     return {"data": data}

--- a/datahub/main.py
+++ b/datahub/main.py
@@ -108,13 +108,15 @@ def get_dsr_data(  # type: ignore[misc]
 ) -> dict[Hashable, Any]:
     """GET method function for getting DSR data as JSON.
 
-    Returns:
-        A Dict containing the DSR list.
-    """
-    filtered_data = dt.dsr_data[start:]
+    Args:
+        start: Starting index for exported list
 
-    if end:
-        filtered_data = filtered_data[: end - start + 1]
+        end: Last index that will be included in exported list
+
+    Returns:
+        A Dict containing the DSR list
+    """
+    filtered_data = dt.dsr_data[start : end + 1 if end else end]
 
     return {"data": filtered_data}
 

--- a/datahub/main.py
+++ b/datahub/main.py
@@ -7,7 +7,6 @@ from pydantic import BaseModel
 from . import data as dt
 from .dsr import DSRModel, validate_dsr_sizes
 from .opal import OpalModel
-from .wesim import get_wesim
 
 app = FastAPI()
 
@@ -119,17 +118,3 @@ def get_dsr_data(  # type: ignore[misc]
     filtered_data = dt.dsr_data[start : end + 1 if end else end]
 
     return {"data": filtered_data}
-
-
-@app.get("/wesim")
-def get_wesim_data() -> dict[Hashable, Any]:  # type: ignore[misc]
-    """GET method function for getting WESIM data as JSON.
-
-    Returns:
-        A Dict containing the WESIM data in JSON format.
-    """
-    data = get_wesim()
-    for value in data.values():
-        value = value.to_dict(orient="split")
-
-    return {"data": data}

--- a/datahub/main.py
+++ b/datahub/main.py
@@ -57,19 +57,23 @@ def get_opal_data(  # type: ignore[misc]
 ) -> dict[Hashable, Any]:
     """GET method function for getting Opal Dataframe as JSON.
 
+    Args:
+        start: Starting index for exported Dataframe
+
+        end: Last index that will be included in exported Dataframe
+
     Returns:
-        A Dict containing the Opal Dataframe in JSON format.
+        A Dict containing the Opal Dataframe in JSON format
 
         This can be converted back to a Dataframe using the following:
         pd.DataFrame(**data)
     """
-    filtered_df = dt.opal_df.loc[dt.opal_df.index >= start]
+    if isinstance(end, int) and end < start:
+        raise HTTPException(
+            status_code=400, detail="End parameter cannot be less than Start parameter."
+        )
 
-    if end:
-        filtered_df = filtered_df.loc[filtered_df.index <= end]
-
-    if filtered_df.empty:
-        raise HTTPException(status_code=404, detail="No data found matching criteria.")
+    filtered_df = dt.opal_df.loc[start:end]
 
     data = filtered_df.to_dict(orient="split")
     return {"data": data}

--- a/datahub/main.py
+++ b/datahub/main.py
@@ -115,6 +115,11 @@ def get_dsr_data(  # type: ignore[misc]
     Returns:
         A Dict containing the DSR list
     """
+    if isinstance(end, int) and end < start:
+        raise HTTPException(
+            status_code=400, detail="End parameter cannot be less than Start parameter."
+        )
+
     filtered_data = dt.dsr_data[start : end + 1 if end else end]
 
     return {"data": filtered_data}

--- a/datahub/main.py
+++ b/datahub/main.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from . import data as dt
 from .dsr import DSRModel, validate_dsr_sizes
 from .opal import OpalModel
+from .wesim import get_wesim
 
 app = FastAPI()
 
@@ -85,3 +86,25 @@ def update_dsr_data(data: DSRModel) -> dict[str, str]:
     dt.dsr_data.append(data_dict)
 
     return {"message": "Data submitted successfully."}
+
+
+@app.get("/dsr")
+def get_dsr_data() -> dict[Hashable, Any]:  # type: ignore[misc]
+    """GET method function for getting DSR data as JSON.
+
+    Returns:
+        A Dict containing the DSR list.
+    """
+    data = dt.dsr_data
+    return {"data": data}
+
+
+@app.get("/wesim")
+def get_wesim_data() -> dict[Hashable, Any]:  # type: ignore[misc]
+    """GET method function for getting WESIM data as JSON.
+
+    Returns:
+        A Dict containing the DSR list.
+    """
+    data = get_wesim()
+    return {"data": data}

--- a/tests/test_dsr.py
+++ b/tests/test_dsr.py
@@ -42,3 +42,33 @@ def test_post_dsr_api_invalid(dsr_data):
 
     response = client.post("/dsr", data=json.dumps(dsr_data))
     assert response.status_code == 422
+
+
+def test_get_dsr_api(dsr_data):
+    """Tests DSR data GET method."""
+    data_1 = dsr_data.copy()
+    data_2 = dsr_data.copy()
+    data_2["Name"] = "Foo"
+    client.post("/dsr", data=json.dumps(data_1))
+    client.post("/dsr", data=json.dumps(data_2))
+
+    response = client.get("/dsr")
+    assert response.json()["data"] == dt.dsr_data
+
+
+def test_dsr_api_get_query(dsr_data):
+    """Tests the query parameters for the DSR GET method."""
+    for x in range(4):
+        exec(f"data_{x + 1} = dsr_data.copy()")
+        exec(f"data_{x + 1}['Name'] = 'DSR_{x + 1}'")
+        post_data = json.dumps(eval(f"data_{x + 1}"))
+        client.post("/opal", data=post_data)
+
+    response = client.get("/dsr?start=2")
+    assert response.json()["data"] == dt.dsr_data[2:]
+
+    response = client.get("/dsr?end=2")
+    assert response.json()["data"] == dt.dsr_data[:3]
+
+    response = client.get("/dsr?start=1&end=2")
+    assert response.json()["data"] == dt.dsr_data[1:3]

--- a/tests/test_dsr.py
+++ b/tests/test_dsr.py
@@ -59,25 +59,12 @@ def test_post_dsr_api_invalid(dsr_data):
     assert response.json()["detail"][0]["msg"] == "field required"
 
 
-def test_get_dsr_api(dsr_data):
+def test_get_dsr_api():
     """Tests DSR data GET method."""
-    data_1 = dsr_data.copy()
-    data_2 = dsr_data.copy()
-    data_2["Name"] = "Foo"
-    client.post("/dsr", data=json.dumps(data_1))
-    client.post("/dsr", data=json.dumps(data_2))
+    dt.dsr_data = [0, 1, 2, 3, 4, 5]
 
     response = client.get("/dsr")
     assert response.json()["data"] == dt.dsr_data
-
-
-def test_dsr_api_get_query(dsr_data):
-    """Tests the query parameters for the DSR GET method."""
-    for x in range(4):
-        exec(f"data_{x + 1} = dsr_data.copy()")
-        exec(f"data_{x + 1}['Name'] = 'DSR_{x + 1}'")
-        post_data = json.dumps(eval(f"data_{x + 1}"))
-        client.post("/opal", data=post_data)
 
     response = client.get("/dsr?start=2")
     assert response.json()["data"] == dt.dsr_data[2:]

--- a/tests/test_opal_api.py
+++ b/tests/test_opal_api.py
@@ -77,7 +77,7 @@ def test_get_opal_api(client, opal_data):
     response = client.get("/opal")
 
     # Converts API response to Dataframe and compares it to global variable.
-    get_data = pd.DataFrame(**response.json())
+    get_data = pd.DataFrame(**response.json()["data"])
     get_data["Time"] = pd.to_datetime(get_data["Time"], format="ISO8601")
 
     assert get_data.equals(dt.opal_df)

--- a/tests/test_opal_api.py
+++ b/tests/test_opal_api.py
@@ -100,7 +100,15 @@ def test_opal_api_get_query(client, opal_data):
     response = client.get("/opal?start=1&end=3")
     assert response.json()["data"]["index"] == [1, 2, 3]
 
-    # Checks that error is raised when data isn't found.
+    # Checks that empty data is returned when data isn't found.
     response = client.get("/opal?start=6")
-    assert response.status_code == 404
-    assert response.json() == {"detail": "No data found matching criteria."}
+    print(response.json())
+    assert response.status_code == 200
+    assert len(response.json()["data"]["index"]) == 0
+
+    # Checks that an error is raised when parameters are invalid.
+    response = client.get("/opal?start=3&end=1")
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": "End parameter cannot be less than Start parameter."
+    }


### PR DESCRIPTION
GET methods for Opal, Agents and Wesim data.

The GET methods for Opal and Agents use the following query parameters to select the data exported:

- `start`: The index from where to start including data (default = 0).
- `end`: Optional parameter, defines the index to stop including data (inclusive).

So the request `/opal?start=2&end=4` provides data for indices 2, 3 and 4.

Closes #82, and #83

Opened as a draft as current Wesim GET method is causing `mypy` tests to fail. We also can't test the Wesim GET method until #57 has been resolved.