### PR TITLE
CI for Automatic Deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,25 @@ jobs:
       run: pip install -r requirements-dev.txt
     - name: Run tests
       run: pytest
+
+  publish:
+      runs-on: ubuntu-latest
+      if: github.ref == 'refs/heads/main'
+      needs: test
+      steps:
+        - name: Login to GitHub Container Registry
+          uses: docker/login-action@v1
+          with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+        - name: Get image metadata
+          id: meta
+          uses: docker/metadata-action@v3
+          with:
+            images: ghcr.io/${{ github.repository }}
+        - name: Build and push Docker image
+          uses: docker/build-push-action@v2
+          with:
+            push: true
+            tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
`publish` job added to `ci.yml` to publish image into GitHub Container Registry.

Closes https://github.com/ImperialCollegeLondon/gridlington-datahub/issues/79