### PR TITLE
Fix markdownlint hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,4 +21,4 @@ repos:
     rev: v0.35.0
     hooks:
       - id: markdownlint
-        args: ["--disable", "MD013"]
+        args: ["--disable", "MD013", "--"]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ API docs can be seen at `localhost:8000/docs`
 5. Run tests: `pytest`. This will create a coverage report inside `htmlcov/`.
 
 ### Dependencies
+
 Dependencies are managed using the [`pip-tools`] tool chain. Unpinned dependencies are specified in `pyproject.toml`. Pinned versions are then produced with: `pip-compile`.
 
 To add/remove packages edit `pyproject.toml` and run the above command. To upgrade all existing dependencies run: `pip-compile --upgrade`.


### PR DESCRIPTION
The markdownlint hook we've been using has broken arguments to it. See: https://github.com/ImperialCollegeLondon/poetry_template_2/pull/41

I re-ran the hooks and fixed a whitespace warning.