### PR TITLE
Use environment variable for wesim data path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@ FROM python:3.10
 
 EXPOSE 80
 
-WORKDIR /code
+WORKDIR /src
 
-COPY ./requirements.txt /code/requirements.txt
+COPY ./requirements.txt /src/requirements.txt
 
-RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+RUN pip install --no-cache-dir --upgrade -r /src/requirements.txt
 
-COPY ./datahub /code/app
+COPY ./datahub /src/app
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "80"]

--- a/datahub/wesim.py
+++ b/datahub/wesim.py
@@ -1,4 +1,5 @@
 """This module defines the data structures for the WESIM model."""
+import os
 from typing import Any, Hashable
 
 import pandas as pd
@@ -12,7 +13,7 @@ REGIONS_KEY = {
 }
 
 INTERCONNECTORS_KEY = {"SCO-IE", "NEW-NOR", "NEW-IE", "SEW-CE"}
-WESIM_DATA_FILE = "../1_Wesim_GB_hourly_data.xlsx"  # TODO: move to config
+WESIM_DATA_FILE = os.environ.get("WESIM_DATA_FILE", "../1_Wesim_GB_hourly_data.xlsx")
 
 
 def read_wesim(wesim_data_file: str) -> dict[int | str, pd.DataFrame]:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,11 @@
 version: '3'
 services:
-  web:
+  app:
     build: .
+    environment:
+      - WESIM_DATA_FILE=/data/wesim_data.xlsx
     ports:
-      - 127.0.0.1:8000:80
+      - 127.0.0.1:80:80
     volumes:
-      - ./datahub:/code/app
+      - ./datahub:/src/app
+      - ../1_Wesim_GB_hourly_data.xlsx:/data/wesim_data.xlsx


### PR DESCRIPTION
This PR standardises some file path names in the docker image and uses an environment variable for the wesim data path so we have control over where we put that volume in the production version.

It is the last step to complete the production server setup

Close #91 