### PR TITLE
Use HDF5 file upload for DSR API data

### DIFF
--- a/datahub/dsr.py
+++ b/datahub/dsr.py
@@ -1,29 +1,30 @@
 """This module defines the data structures for the MEDUSA Demand Simulator model."""
 import numpy as np
+from numpy.typing import NDArray
 from pydantic import BaseModel, Field
 
 
 class DSRModel(BaseModel):
     """Define required key values for Demand Side Response data."""
 
-    amount: list = Field(alias="Amount", size=(13,))
-    cost: list = Field(alias="Cost", size=(1440, 13))
-    kwh_cost: list = Field(alias="kWh Cost", size=(2,))
-    activities: list = Field(alias="Activities", size=(1440, 7))
+    amount: list = Field(alias="Amount", shape=(13,))
+    cost: list = Field(alias="Cost", shape=(1440, 13))
+    kwh_cost: list = Field(alias="kWh Cost", shape=(2,))
+    activities: list = Field(alias="Activities", shape=(1440, 7))
     activities_outside_home: list = Field(
-        alias="Activities Outside Home", size=(1440, 7)
+        alias="Activities Outside Home", shape=(1440, 7)
     )
-    activity_types: list = Field(alias="Activity Types", size=(7,))
-    ev_id_matrix: list = Field(alias="EV ID Matrix", default=None, size=(1440, 4329))
-    ev_dt: list = Field(alias="EV DT", size=(1440, 2))
-    ev_locations: list = Field(alias="EV Locations", default=None, size=(1440, 4329))
-    ev_battery: list = Field(alias="EV Battery", default=None, size=(1440, 4329))
-    ev_state: list = Field(alias="EV State", size=(1440, 4329))
-    ev_mask: list = Field(alias="EV Mask", default=None, size=(1440, 4329))
-    baseline_ev: list = Field(alias="Baseline EV", size=(1440,))
-    baseline_non_ev: list = Field(alias="Baseline Non-EV", size=(1440,))
-    actual_ev: list = Field(alias="Actual EV", size=(1440,))
-    actual_non_ev: list = Field(alias="Actual Non-EV", size=(1440,))
+    activity_types: list = Field(alias="Activity Types", shape=(7,))
+    ev_id_matrix: list = Field(alias="EV ID Matrix", default=None, shape=(1440, 4329))
+    ev_dt: list = Field(alias="EV DT", shape=(1440, 2))
+    ev_locations: list = Field(alias="EV Locations", default=None, shape=(1440, 4329))
+    ev_battery: list = Field(alias="EV Battery", default=None, shape=(1440, 4329))
+    ev_state: list = Field(alias="EV State", shape=(1440, 4329))
+    ev_mask: list = Field(alias="EV Mask", default=None, shape=(1440, 4329))
+    baseline_ev: list = Field(alias="Baseline EV", shape=(1440,))
+    baseline_non_ev: list = Field(alias="Baseline Non-EV", shape=(1440,))
+    actual_ev: list = Field(alias="Actual EV", shape=(1440,))
+    actual_non_ev: list = Field(alias="Actual Non-EV", shape=(1440,))
     name: str = Field(alias="Name", default="")
     warn: str = Field(alias="Warn", default="")
 
@@ -33,8 +34,8 @@ class DSRModel(BaseModel):
         allow_population_by_field_name = True
 
 
-def validate_dsr_arrays(data: dict[str, str | list]) -> list[str]:
-    """Validate the sizes of the arrays in the DSR data.
+def validate_dsr_arrays(data: dict[str, str | NDArray]) -> list[str]:
+    """Validate the shapes of the arrays in the DSR data.
 
     Args:
         data: The dictionary representation of the DSR Data. The keys are field aliases.
@@ -45,12 +46,14 @@ def validate_dsr_arrays(data: dict[str, str | list]) -> list[str]:
     """
     aliases = []
     for alias, field in DSRModel.schema()["properties"].items():
-        if field["type"] == "array":
-            try:
-                array = np.array(data[alias])
-            except ValueError:
-                aliases.append(alias)
-                continue
-            if array.shape != field["size"] or array.dtype != np.float64:
+        try:
+            element = data[alias]
+        except ValueError:
+            aliases.append(alias)
+            continue
+        if isinstance(element, np.ndarray):
+            if element.shape != field["shape"] or not np.issubdtype(
+                element.dtype, np.number
+            ):
                 aliases.append(alias)
     return aliases

--- a/datahub/dsr.py
+++ b/datahub/dsr.py
@@ -34,7 +34,7 @@ class DSRModel(BaseModel):
         allow_population_by_field_name = True
 
 
-def validate_dsr_arrays(data: dict[str, str | NDArray]) -> list[str]:
+def validate_dsr_arrays(data: dict[str, NDArray]) -> list[str]:
     """Validate the shapes of the arrays in the DSR data.
 
     Args:
@@ -47,13 +47,13 @@ def validate_dsr_arrays(data: dict[str, str | NDArray]) -> list[str]:
     aliases = []
     for alias, field in DSRModel.schema()["properties"].items():
         try:
-            element = data[alias]
+            array = data[alias]
         except ValueError:
             aliases.append(alias)
             continue
-        if isinstance(element, np.ndarray):
-            if element.shape != field["shape"] or not np.issubdtype(
-                element.dtype, np.number
+        if field["type"] == "array":
+            if array.shape != field["shape"] or not np.issubdtype(
+                array.dtype, np.number
             ):
                 aliases.append(alias)
     return aliases

--- a/datahub/main.py
+++ b/datahub/main.py
@@ -1,7 +1,7 @@
 """Script for running Datahub API."""
 from typing import Any, Hashable
 
-import h5py
+import h5py  # type: ignore
 from fastapi import FastAPI, HTTPException, UploadFile
 from pydantic import BaseModel
 

--- a/datahub/main.py
+++ b/datahub/main.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 from . import data as dt
 from . import log
-from .dsr import validate_dsr_arrays
+from .dsr import validate_dsr_data
 from .opal import OpalModel
 from .wesim import get_wesim
 
@@ -92,7 +92,8 @@ def get_opal_data(  # type: ignore[misc]
 def upload_dsr(file: UploadFile) -> dict[str, str | None]:
     """POST method for appending data to the DSR list.
 
-    This takes a HDF5 file as input.
+    This takes a HDF5 file as input. Data specification can be found at
+    https://github.com/ImperialCollegeLondon/gridlington-datahub/wiki/Agent-model-data#output
 
     \f
 
@@ -108,10 +109,9 @@ def upload_dsr(file: UploadFile) -> dict[str, str | None]:
     log.info("Recieved Opal data.")
     with h5py.File(file.file, "r") as h5file:
         data = {key: value[...] for key, value in h5file.items()}
-    if alias := validate_dsr_arrays(data):
-        raise HTTPException(
-            status_code=400, detail=f"Invalid size for: {', '.join(alias)}."
-        )
+
+    validate_dsr_data(data)
+
     log.info("Appending new data...")
     log.debug(f"Current DSR data length: {len(dt.dsr_data)}")
     dt.dsr_data.append(data)

--- a/datahub/main.py
+++ b/datahub/main.py
@@ -63,7 +63,6 @@ def get_opal_data(  # type: ignore[misc]
 
     Args:
         start: Starting index for exported Dataframe
-
         end: Last index that will be included in exported Dataframe
 
     Returns:
@@ -92,8 +91,33 @@ def get_opal_data(  # type: ignore[misc]
 def upload_dsr(file: UploadFile) -> dict[str, str | None]:
     """POST method for appending data to the DSR list.
 
-    This takes a HDF5 file as input. Data specification can be found at
-    https://github.com/ImperialCollegeLondon/gridlington-datahub/wiki/Agent-model-data#output
+    This takes a HDF5 file as input. This file has a flat structure, with each dataset
+    available at the top level.
+
+    The required fields (datasets) are:
+    - Amount (13 x 1)
+    - Cost (1440 x 13)
+    - kWh Cost (2 x 1)
+    - Activities (1440 x 7)
+    - Activities Outside Home (1440 x 7)
+    - Activity Types (7 x 1)
+    - EV DT (1440 x 2)
+    - EV State (1440 x 4329)
+    - Baseline EV (1440 x 1)
+    - Baseline Non-EV (1440 x 1)
+    - Actual EV (1440 x 1)
+    - Actual Non-EV (1440 x 1)
+
+    The optional fields are:
+    - EV ID Matrix (1440 x 4329)
+    - EV Locations (1440 x 4329)
+    - EV Battery (1440 x 4329)
+    - EV Mask (1440 x 4329)
+    - Name (str)
+    - Warn (str)
+
+    Further details for the DSR data specification can be found in
+    [the GitHub wiki.](https://github.com/ImperialCollegeLondon/gridlington-datahub/wiki/Agent-model-data#output)
 
     \f
 
@@ -128,7 +152,6 @@ def get_dsr_data(  # type: ignore[misc]
 
     Args:
         start: Starting index for exported list
-
         end: Last index that will be included in exported list
 
     Returns:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,9 @@ requires-python = ">=3.10"
 dependencies = [
     "pandas[excel]",
     "fastapi",
-    "uvicorn"
+    "uvicorn",
+    "python-multipart",
+    "h5py"
 ]
 
 [project.optional-dependencies]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -47,6 +47,8 @@ h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
+h5py==3.9.0
+    # via datahub (pyproject.toml)
 httpcore==0.17.2
     # via httpx
 httpx==0.24.1
@@ -71,6 +73,7 @@ nodeenv==1.8.0
     # via pre-commit
 numpy==1.25.0
     # via
+    #   h5py
     #   pandas
     #   pandas-stubs
 odfpy==1.4.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -116,6 +116,8 @@ pytest-mypy==0.10.3
     # via datahub (pyproject.toml)
 python-dateutil==2.8.2
     # via pandas
+python-multipart==0.0.6
+    # via datahub (pyproject.toml)
 pytz==2023.3
     # via pandas
 pyxlsb==1.0.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,10 +18,14 @@ fastapi==0.99.1
     # via datahub (pyproject.toml)
 h11==0.14.0
     # via uvicorn
+h5py==3.9.0
+    # via datahub (pyproject.toml)
 idna==3.4
     # via anyio
 numpy==1.25.0
-    # via pandas
+    # via
+    #   h5py
+    #   pandas
 odfpy==1.4.1
     # via pandas
 openpyxl==3.1.2
@@ -32,6 +36,8 @@ pydantic==1.10.10
     # via fastapi
 python-dateutil==2.8.2
     # via pandas
+python-multipart==0.0.6
+    # via datahub (pyproject.toml)
 pytz==2023.3
     # via pandas
 pyxlsb==1.0.10

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import random
 
+import h5py
 import numpy as np
 import pytest
 from fastapi.testclient import TestClient
@@ -38,12 +39,33 @@ def opal_data_array():
 
 
 @pytest.fixture
-def dsr_data():
-    """Pytest Fixture for random Opal data input."""
-    data = {}
-    for field in list(DSRModel.__fields__.values()):
-        if field.annotation == str:
-            data[field.alias] = "Name or Warning"
-        else:
-            data[field.alias] = np.random.rand(*field.field_info.extra["size"]).tolist()
+def dsr_data(dsr_data_path):
+    """Pytest Fixture for DSR data as a dictionary."""
+    with h5py.File(dsr_data_path, "r") as h5file:
+        data = {key: value[...] for key, value in h5file.items()}
     return data
+
+
+@pytest.fixture
+def dsr_data_path(tmp_path):
+    """The path to a temporary HDF5 file with first-time-only generated DSR data."""
+    # Define the file path within the temporary directory
+    file_path = tmp_path / "data.h5"
+
+    # Check if the file already exists
+    if file_path.is_file():
+        # If the file exists, return its path
+        return file_path
+
+    # Otherwise, create and write data to the file
+    with h5py.File(file_path, "w") as h5file:
+        for field in list(DSRModel.__fields__.values()):
+            if field.annotation == str:
+                h5file[field.alias] = "Name or Warning"
+            else:
+                h5file[field.alias] = np.random.rand(
+                    *field.field_info.extra["shape"]
+                ).astype("float16")
+
+    # Return the path to the file
+    return file_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import random
 
-import h5py
+import h5py  # type: ignore
 import numpy as np
 import pytest
 from fastapi.testclient import TestClient

--- a/tests/test_dsr.py
+++ b/tests/test_dsr.py
@@ -1,5 +1,5 @@
-import json
-
+import h5py
+import numpy as np
 import pytest
 from fastapi.testclient import TestClient
 
@@ -7,7 +7,6 @@ from datahub import data as dt
 from datahub.main import app
 
 client = TestClient(app)
-client.headers["Content-Type"] = "application/json"
 
 
 @pytest.fixture(autouse=True)
@@ -18,45 +17,50 @@ def reset_dsr_data():
 
 def test_validate_dsr_arrays(dsr_data):
     """Tests the validate_dsr_arrays function."""
-    from datahub.dsr import DSRModel, validate_dsr_arrays
+    from datahub.dsr import validate_dsr_arrays
 
-    dsr = DSRModel(**dsr_data)
+    assert validate_dsr_arrays(dsr_data) == []
 
-    assert validate_dsr_arrays(dsr.dict(by_alias=True)) == []
+    dsr_data["Amount"] = np.append(dsr_data["Amount"], 1.0)
+    dsr_data["Cost"] = np.delete(dsr_data["Cost"], 1)
 
-    dsr.amount.append(1.0)
-    dsr.cost.pop()
-
-    assert validate_dsr_arrays(dsr.dict(by_alias=True)) == ["Amount", "Cost"]
+    assert validate_dsr_arrays(dsr_data) == ["Amount", "Cost"]
 
 
-def test_post_dsr_api(dsr_data):
-    """Tests POSTing DSR data to API."""
-    # Checks that a POST request can be successfully made
-    response = client.post("/dsr", data=json.dumps(dsr_data))
+def test_post_dsr_api(dsr_data_path):
+    """Tests POSTing DSR data as a hdf5 file to the API."""
+    with open(dsr_data_path, "rb") as dsr_data:
+        response = client.post("/dsr", files={"file": dsr_data})
+
     assert response.status_code == 200
-    assert response.json() == {"message": "Data submitted successfully."}
+    assert response.json() == {"filename": dsr_data_path.name}
 
     # Checks that the DSR global variable has been updated
     assert len(dt.dsr_data) == 1
 
 
-def test_post_dsr_api_invalid(dsr_data):
+def test_post_dsr_api_invalid(dsr_data_path):
     """Tests POSTing DSR data to API."""
-    # Checks invalid array lengths raises an error
-    dsr_data["Amount"].append(1.0)
-    dsr_data["Cost"][0].pop()
+    with h5py.File(dsr_data_path, "r+") as dsr_data:
+        # Checks invalid array lengths raises an error
+        amount = dsr_data.pop("Amount")[...]
+        dsr_data["Amount"] = np.append(amount, 1.0)
+        cost = dsr_data.pop("Cost")[...]
+        dsr_data["Cost"] = cost[1:]
 
-    response = client.post("/dsr", data=json.dumps(dsr_data))
-    assert response.status_code == 400
-    assert response.json() == {"detail": "Invalid size for: Amount, Cost."}
+    with open(dsr_data_path, "rb") as dsr_data:
+        response = client.post("/dsr", files={"file": dsr_data})
+        assert response.status_code == 400
+        assert response.json() == {"detail": "Invalid size for: Amount, Cost."}
 
-    # Checks missing fields raises an error
-    dsr_data.pop("Amount")
+    with h5py.File(dsr_data_path, "r+") as dsr_data:
+        # Checks missing fields raises an error
+        dsr_data.pop("Amount")
 
-    response = client.post("/dsr", data=json.dumps(dsr_data))
-    assert response.status_code == 422
-    assert response.json()["detail"][0]["msg"] == "field required"
+    with open(dsr_data_path, "rb") as dsr_data:
+        response = client.post("/dsr", files={"file": dsr_data})
+        assert response.status_code == 422
+        assert response.json()["detail"][0]["msg"] == "field required"
 
 
 def test_get_dsr_api():

--- a/tests/test_dsr.py
+++ b/tests/test_dsr.py
@@ -1,4 +1,4 @@
-import h5py
+import h5py  # type: ignore
 import numpy as np
 import pytest
 from fastapi.testclient import TestClient


### PR DESCRIPTION
This PR changes the POST request at the `/dsr` endpoint to accept a HDF5 file instead of json data.

It improves the performance and memory efficiency significantly. Previously it was taking ~20 seconds to process around 0.5GB of json data, now it takes around 700ms to process closer to 100MB of data in this HDF5 format.

Close #71 