### PR TITLE
Use orjson to encode numpy array in DSR GET method

### DIFF
--- a/datahub/data.py
+++ b/datahub/data.py
@@ -1,8 +1,9 @@
 """This module defines the data structures for each of the models."""
 import pandas as pd
+from numpy.typing import NDArray
 
 from .opal import create_opal_frame
 
 opal_df: pd.DataFrame = create_opal_frame()
-dsr_data: list[dict[str, str | list]] = []  # type: ignore[type-arg]
+dsr_data: list[dict[str, NDArray | str]] = []  # type: ignore[type-arg]
 wesim_data: dict[str, dict] = {}  # type: ignore[type-arg]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "uvicorn",
     "python-multipart",
     "h5py",
+    "orjson",
 ]
 
 [project.optional-dependencies]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -93,7 +93,7 @@ pandas-stubs==2.0.2.230605
     # via datahub (pyproject.toml)
 pathspec==0.11.2
     # via black
-pip-tools==6.14.0
+pip-tools==7.2.0
     # via datahub (pyproject.toml)
 platformdirs==3.8.0
     # via

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -80,6 +80,8 @@ odfpy==1.4.1
     # via pandas
 openpyxl==3.1.2
     # via pandas
+orjson==3.9.2
+    # via datahub (pyproject.toml)
 packaging==23.1
     # via
     #   black

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,8 @@ odfpy==1.4.1
     # via pandas
 openpyxl==3.1.2
     # via pandas
+orjson==3.9.2
+    # via datahub (pyproject.toml)
 pandas[excel]==2.0.3
     # via datahub (pyproject.toml)
 pydantic==1.10.10

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 from fastapi.testclient import TestClient
 
-from datahub.dsr import DSRModel
+from datahub.dsr import DSRModel, read_dsr_file
 from datahub.main import app
 from datahub.opal import opal_headers
 
@@ -41,9 +41,7 @@ def opal_data_array():
 @pytest.fixture
 def dsr_data(dsr_data_path):
     """Pytest Fixture for DSR data as a dictionary."""
-    with h5py.File(dsr_data_path, "r") as h5file:
-        data = {key: value[...] for key, value in h5file.items()}
-    return data
+    return read_dsr_file(dsr_data_path)
 
 
 @pytest.fixture
@@ -65,7 +63,7 @@ def dsr_data_path(tmp_path):
             else:
                 h5file[field.alias] = np.random.rand(
                     *field.field_info.extra["shape"]
-                ).astype("float16")
+                ).astype("float32")
 
     # Return the path to the file
     return file_path


### PR DESCRIPTION
This PR fixes the DSR GET method so that it can encode the numpy array as JSON. There might be issues with size and speed of the data transfer to the visualisation system with this. It might be more sensible to send only specific sections of the DSR data or re-encode it as a HDF5 file and send it but this is the least disruptive change for now and we will revisit it it once we get to coding the Visualisation system.

Close #107 