### PR TITLE
DSR GET Method - Filter by Column

### DIFF
--- a/datahub/dsr.py
+++ b/datahub/dsr.py
@@ -38,6 +38,13 @@ class DSRModel(BaseModel):
         allow_population_by_field_name = True
 
 
+dsr_headers = {
+    field["title"]: name
+    for name, field in DSRModel.schema(by_alias=False)["properties"].items()
+    if name != "frame"
+}
+
+
 def validate_dsr_data(data: dict[str, NDArray | str]) -> None:
     """Validate the shapes of the arrays in the DSR data.
 

--- a/datahub/dsr.py
+++ b/datahub/dsr.py
@@ -41,7 +41,6 @@ class DSRModel(BaseModel):
 dsr_headers = {
     field["title"]: name
     for name, field in DSRModel.schema(by_alias=False)["properties"].items()
-    if name != "frame"
 }
 
 

--- a/datahub/main.py
+++ b/datahub/main.py
@@ -209,13 +209,10 @@ def get_dsr_data(
         log.info("Filtering data by column...")
         filtered_data = []
         for frame in filtered_index_data:
-            log.debug(f"Frame keys: {frame.keys()}")
             filtered_keys = {}
             for key in frame.keys():
-                log.debug(f"Key: {key}")
                 if key.lower() in columns:
                     filtered_keys[key] = frame[key]
-            log.debug(f"Filtered keys: {filtered_keys.keys()}")
             filtered_data.append(filtered_keys)
 
         return ORJSONResponse({"data": filtered_data})

--- a/datahub/main.py
+++ b/datahub/main.py
@@ -176,7 +176,7 @@ def get_dsr_data(
     Args:
         start: Starting index for exported list
         end: Last index that will be included in exported list
-        col: Column names to filter by
+        col: Column names to filter by, multiple values seperated by comma
 
     Returns:
         A Dict containing the DSR list

--- a/datahub/main.py
+++ b/datahub/main.py
@@ -190,7 +190,8 @@ def get_dsr_data(
 
     log.info("Filtering data by index...")
     log.debug(f"Current DSR data length:\n\n{len(dt.dsr_data)}")
-    filtered_data = dt.dsr_data[start : end + 1 if end else end]
+    data = dt.dsr_data.copy()
+    filtered_index_data = data[start : end + 1 if end else end]
     log.debug(f"Filtered DSR data length:\n\n{len(dt.dsr_data)}")
 
     if isinstance(col, str):
@@ -206,16 +207,20 @@ def get_dsr_data(
                 raise HTTPException(status_code=400, detail=message)
 
         log.info("Filtering data by column...")
-        for frame in filtered_data:
-            delete_keys = []
+        filtered_data = []
+        for frame in filtered_index_data:
+            log.debug(f"Frame keys: {frame.keys()}")
+            filtered_keys = {}
             for key in frame.keys():
-                if key.lower() not in columns:
-                    delete_keys.append(key)
+                log.debug(f"Key: {key}")
+                if key.lower() in columns:
+                    filtered_keys[key] = frame[key]
+            log.debug(f"Filtered keys: {filtered_keys.keys()}")
+            filtered_data.append(filtered_keys)
 
-            for key in delete_keys:
-                del frame[key]
+        return ORJSONResponse({"data": filtered_data})
 
-    return ORJSONResponse({"data": filtered_data})
+    return ORJSONResponse({"data": filtered_index_data})
 
 
 @app.get("/wesim")

--- a/datahub/main.py
+++ b/datahub/main.py
@@ -155,7 +155,9 @@ def upload_dsr(file: UploadFile) -> dict[str, str | None]:
 
 
 @app.get("/dsr", response_class=ORJSONResponse)
-def get_dsr_data(start: int = 0, end: int | None = None) -> ORJSONResponse:
+def get_dsr_data(
+    start: int = len(dt.dsr_data) - 1, end: int | None = None
+) -> ORJSONResponse:
     """GET method function for getting DSR data as JSON.
 
     It takes optional query parameters of:

--- a/tests/test_dsr_api.py
+++ b/tests/test_dsr_api.py
@@ -100,3 +100,10 @@ def test_get_dsr_api(dsr_data):
     assert len(response.json()["data"][0].keys()) == 2
     assert "Activity Types" in response.json()["data"][0].keys()
     assert "kWh Cost" in response.json()["data"][0].keys()
+
+    response = client.get("/dsr?start=1&col=activities")
+    assert len(response.json()["data"]) == 2
+    assert len(response.json()["data"][0].keys()) == 1
+    assert "Activities" in response.json()["data"][0].keys()
+    assert len(response.json()["data"][1].keys()) == 1
+    assert "Activities" in response.json()["data"][1].keys()

--- a/tests/test_dsr_api.py
+++ b/tests/test_dsr_api.py
@@ -96,7 +96,7 @@ def test_get_dsr_api(dsr_data):
     assert len(response.json()["data"][0].keys()) == 1
     assert "Activities" in response.json()["data"][0].keys()
 
-    response = client.get("/dsr?col=activity types,kwh cost")
+    response = client.get("/dsr?col=activity_types,kwh_cost")
     assert len(response.json()["data"][0].keys()) == 2
     assert "Activity Types" in response.json()["data"][0].keys()
     assert "kWh Cost" in response.json()["data"][0].keys()

--- a/tests/test_dsr_api.py
+++ b/tests/test_dsr_api.py
@@ -76,3 +76,12 @@ def test_get_dsr_api(dsr_data):
 
     response = client.get("/dsr?start=1")
     assert response.json()["data"][0]["Name"] == dt.dsr_data[1]["Name"]
+
+    response = client.get("/dsr?col=activities")
+    assert len(response.json()["data"][0].keys()) == 1
+    assert "Activities" in response.json()["data"][0].keys()
+
+    response = client.get("/dsr?col=activity types,kwh cost")
+    assert len(response.json()["data"][0].keys()) == 2
+    assert "Activity Types" in response.json()["data"][0].keys()
+    assert "kWh Cost" in response.json()["data"][0].keys()

--- a/tests/test_dsr_api.py
+++ b/tests/test_dsr_api.py
@@ -73,10 +73,25 @@ def test_get_dsr_api(dsr_data):
     new_data = dsr_data.copy()
     new_data["Name"] = "A new entry"
     dt.dsr_data.append(new_data)
+    new_data = dsr_data.copy()
+    new_data["Name"] = "Another new entry"
+    dt.dsr_data.append(new_data)
 
+    response = client.get("/dsr")
+    assert response.json()["data"][0]["Name"] == dt.dsr_data[2]["Name"]
+
+    # Checks index filtering
     response = client.get("/dsr?start=1")
+    assert len(response.json()["data"]) == 2
     assert response.json()["data"][0]["Name"] == dt.dsr_data[1]["Name"]
+    assert response.json()["data"][1]["Name"] == dt.dsr_data[2]["Name"]
 
+    response = client.get("/dsr?start=0&end=1")
+    assert len(response.json()["data"]) == 2
+    assert response.json()["data"][0]["Name"] == dt.dsr_data[0]["Name"]
+    assert response.json()["data"][1]["Name"] == dt.dsr_data[1]["Name"]
+
+    # Checks column filtering
     response = client.get("/dsr?col=activities")
     assert len(response.json()["data"][0].keys()) == 1
     assert "Activities" in response.json()["data"][0].keys()


### PR DESCRIPTION
Added functionality for filtering by column when making a GET request for DSR data. Columns can be specified with a query parameter with multiple values being separated by comma. E.g. `/dsr?col=activity types,kwh cost`

Default behaviour of index filtering has also been modified. By default, the DSR GET method now only exports the most recent value in the DSR data array. This can be changed with the `start` and `end` query parameters.

Closes #131 

Opened in draft as tests need to be updated.