### PR TITLE
Convert arrays of strings to lists of strings before converting to json

### DIFF
--- a/datahub/main.py
+++ b/datahub/main.py
@@ -1,4 +1,5 @@
 """Script for running Datahub API."""
+import numpy as np
 from fastapi import FastAPI, HTTPException, UploadFile
 from fastapi.responses import ORJSONResponse
 
@@ -215,7 +216,12 @@ def get_dsr_data(
             filtered_keys = {}
             for key in frame.keys():
                 if dsr_headers[key.title()] in columns:
-                    filtered_keys[key] = frame[key]
+                    array = frame[key]
+                    if not isinstance(array, str) and np.issubdtype(
+                        array.dtype, np.character
+                    ):
+                        array = array.astype(str).tolist()
+                    filtered_keys[key] = array
             filtered_data.append(filtered_keys)
 
         return ORJSONResponse({"data": filtered_data})


### PR DESCRIPTION
The DSR GET endpoint was failing with real data because one of the arrays is an array of strings and ORJSON cannot covert a numpy array of string to json. Conveniently, the solution to this is to convert the numpy array into a list of strings, which is perfectly compatible with json.

Close #193 