### PR TITLE
Reset data after model has completed resetting and is ready

### DIFF
--- a/datahub/main.py
+++ b/datahub/main.py
@@ -282,6 +282,9 @@ def set_model_signals(start: bool) -> str:
 def signal_model_ready(ready: bool) -> str:
     """POST method function for indicating when the model has reset and is ready to run.
 
+    This will reset the data in the DataHub to it's initial (empty) values when the
+    ready signal is received as True.
+
     It has the query parameter:
     - `ready`: A boolean to indicate the model has completed setup and is ready.
 
@@ -296,6 +299,9 @@ def signal_model_ready(ready: bool) -> str:
     message = "Ready signal received" if ready else "Not-Ready signal received"
     log.info(message)
     dt.model_resetting = not ready
+
+    if ready:
+        dt.reset_data()
 
     return message
 


### PR DESCRIPTION
The simplest way to reset the data in the datahub is to combine it with the `/model_ready` signal. This is simple and follows the expected behaviour from Yue's side with running the model.

This was decided after discussing with @yuezhu71

Close #222 